### PR TITLE
Add pregnancy CSV import utility

### DIFF
--- a/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
@@ -1,0 +1,32 @@
+import argparse
+
+import pandas as pd
+from django.core.management.base import BaseCommand
+
+from va_explorer.va_data_management.utils.pregnancy_loading import (
+    apply_reference_to_dataframe,
+    build_reference_from_xlsform,
+    load_pregnancies_from_dataframe,
+)
+
+
+class Command(BaseCommand):
+    help = "Loads a pregnancy CSV file into the database"
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv_file", type=argparse.FileType("r"))
+        parser.add_argument(
+            "--form-definition",
+            type=str,
+            required=True,
+            help="Path to the XLSForm defining pregnancy choices",
+        )
+
+    def handle(self, *args, **options):
+        csv_df = pd.read_csv(options["csv_file"], low_memory=False)
+        form_path = options["form_definition"]
+
+        field_map, choice_map = build_reference_from_xlsform(form_path)
+        csv_df = apply_reference_to_dataframe(csv_df, field_map, choice_map)
+        new_objs = load_pregnancies_from_dataframe(csv_df)
+        self.stdout.write(f"Loaded {len(new_objs)} pregnancies from CSV")

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
@@ -1,12 +1,12 @@
 import argparse
 
 import pandas as pd
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from va_explorer.va_data_management.utils.pregnancy_loading import (
     apply_reference_to_dataframe,
-    build_reference_from_xlsform,
     load_pregnancies_from_dataframe,
+    load_reference_from_db,
 )
 
 
@@ -15,18 +15,17 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("csv_file", type=argparse.FileType("r"))
-        parser.add_argument(
-            "--form-definition",
-            type=str,
-            required=True,
-            help="Path to the XLSForm defining pregnancy choices",
-        )
 
     def handle(self, *args, **options):
         csv_df = pd.read_csv(options["csv_file"], low_memory=False)
-        form_path = options["form_definition"]
 
-        field_map, choice_map = build_reference_from_xlsform(form_path)
+        field_map, choice_map = load_reference_from_db()
+        if not field_map or not choice_map:
+            raise CommandError(
+                "Pregnancy definitions have not been loaded. "
+                "Run load_pregnancy_definitions first."
+            )
+
         csv_df = apply_reference_to_dataframe(csv_df, field_map, choice_map)
         new_objs = load_pregnancies_from_dataframe(csv_df)
         self.stdout.write(f"Loaded {len(new_objs)} pregnancies from CSV")

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_definitions.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_definitions.py
@@ -1,0 +1,25 @@
+import argparse
+
+from django.core.management.base import BaseCommand
+
+from va_explorer.va_data_management.utils.pregnancy_loading import (
+    build_reference_from_xlsform,
+    save_reference_to_db,
+)
+
+
+class Command(BaseCommand):
+    help = "Loads pregnancy ODK definition XLSForm into reference tables"
+
+    def add_arguments(self, parser):
+        parser.add_argument("xlsform", type=argparse.FileType("rb"))
+
+    def handle(self, *args, **options):
+        field_map, choice_map = build_reference_from_xlsform(options["xlsform"])
+        if not field_map or not choice_map:
+            self.stdout.write("No survey or choices sheet found in XLSForm")
+            return
+        save_reference_to_db(field_map, choice_map)
+        self.stdout.write(
+            f"Loaded {len(field_map)} fields and {sum(len(c) for c in choice_map.values())} choices"
+        )

--- a/va_explorer/va_data_management/migrations/0029_pregnancy_reference_models.py
+++ b/va_explorer/va_data_management/migrations/0029_pregnancy_reference_models.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+import uuid
+import simple_history.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('va_data_management', '0028_auto_20250708_0000'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PregnancyFieldReference',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False)),
+                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, unique=True)),
+                ('name', models.CharField(max_length=255, unique=True)),
+                ('list_name', models.CharField(max_length=255)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+                ('history', simple_history.models.HistoricalRecords()),
+            ],
+        ),
+        migrations.CreateModel(
+            name='PregnancyChoiceReference',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False)),
+                ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, unique=True)),
+                ('list_name', models.CharField(max_length=255)),
+                ('name', models.CharField(max_length=255)),
+                ('label', models.TextField(blank=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+                ('history', simple_history.models.HistoricalRecords()),
+            ],
+            options={
+                'unique_together': {('list_name', 'name')},
+            },
+        ),
+    ]

--- a/va_explorer/va_data_management/models/__init__.py
+++ b/va_explorer/va_data_management/models/__init__.py
@@ -1,27 +1,29 @@
+from .death import Death
 from .household_census import Household
 from .pregnancy import Pregnancy
 from .pregnancy_outcome import PregnancyOutcome
-from .death import Death
+from .pregnancy_reference import PregnancyChoiceReference, PregnancyFieldReference
 from .verbal_autopsy import (
-    VerbalAutopsy, 
-    Location, 
-    CauseCodingIssue, 
-    questions_to_autodetect_duplicates,
+    CauseCodingIssue,
     CauseOfDeath,
     CODCodesDHIS,
-    DhisStatus
+    DhisStatus,
+    Location,
+    VerbalAutopsy,
+    questions_to_autodetect_duplicates,
 )
 
-__all__ = [
-    'Household',
-    'Pregnancy',
-    'PregnancyOutcome',
-    'Death',
-    'VerbalAutopsy', 
-    'Location',
-    'CauseCodingIssue',
-    'questions_to_autodetect_duplicates',
-    'CauseOfDeath',
-    'CODCodesDHIS',
-     'DhisStatus'
+__all__ = [    "Household",
+    "Pregnancy",
+    "PregnancyOutcome",
+    "Death",
+    "PregnancyFieldReference",
+    "PregnancyChoiceReference",
+    "VerbalAutopsy",
+    "Location",
+    "CauseCodingIssue",
+    "questions_to_autodetect_duplicates",
+    "CauseOfDeath",
+    "CODCodesDHIS",
+    "DhisStatus",
 ]

--- a/va_explorer/va_data_management/models/pregnancy_reference.py
+++ b/va_explorer/va_data_management/models/pregnancy_reference.py
@@ -1,0 +1,36 @@
+import uuid
+
+from django.db import models
+from simple_history.models import HistoricalRecords
+
+
+class PregnancyFieldReference(models.Model):
+    """Reference mapping of pregnancy form fields to choice lists."""
+
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
+    name = models.CharField(max_length=255, unique=True)
+    list_name = models.CharField(max_length=255)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+    history = HistoricalRecords()
+
+    def __str__(self):
+        return f"{self.name} -> {self.list_name}"
+
+
+class PregnancyChoiceReference(models.Model):
+    """Reference mapping of list values to labels."""
+
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
+    list_name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
+    label = models.TextField(blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+    history = HistoricalRecords()
+
+    class Meta:
+        unique_together = ("list_name", "name")
+
+    def __str__(self):
+        return f"{self.list_name}:{self.name} -> {self.label}"

--- a/va_explorer/va_data_management/utils/pregnancy_loading.py
+++ b/va_explorer/va_data_management/utils/pregnancy_loading.py
@@ -1,7 +1,11 @@
 import pandas as pd
 from simple_history.utils import bulk_create_with_history
 
-from va_explorer.va_data_management.models import Pregnancy
+from va_explorer.va_data_management.models import (
+    Pregnancy,
+    PregnancyChoiceReference,
+    PregnancyFieldReference,
+)
 
 
 def build_reference_from_xlsform(xls_path):
@@ -42,6 +46,35 @@ def build_reference_from_xlsform(xls_path):
             label = name
         choice_map.setdefault(list_name, {})[str(name)] = str(label)
 
+    return field_map, choice_map
+
+
+def save_reference_to_db(field_map, choice_map):
+    """Persist reference mappings to the database."""
+    PregnancyFieldReference.objects.all().delete()
+    PregnancyChoiceReference.objects.all().delete()
+
+    field_objs = [
+        PregnancyFieldReference(name=name, list_name=list_name)
+        for name, list_name in field_map.items()
+    ]
+    PregnancyFieldReference.objects.bulk_create(field_objs)
+
+    choice_objs = []
+    for list_name, mapping in choice_map.items():
+        for name, label in mapping.items():
+            choice_objs.append(
+                PregnancyChoiceReference(list_name=list_name, name=name, label=label)
+            )
+    PregnancyChoiceReference.objects.bulk_create(choice_objs)
+
+
+def load_reference_from_db():
+    """Load reference mappings from the database."""
+    field_map = {f.name: f.list_name for f in PregnancyFieldReference.objects.all()}
+    choice_map = {}
+    for choice in PregnancyChoiceReference.objects.all():
+        choice_map.setdefault(choice.list_name, {})[choice.name] = choice.label
     return field_map, choice_map
 
 

--- a/va_explorer/va_data_management/utils/pregnancy_loading.py
+++ b/va_explorer/va_data_management/utils/pregnancy_loading.py
@@ -1,0 +1,77 @@
+import pandas as pd
+from simple_history.utils import bulk_create_with_history
+
+from va_explorer.va_data_management.models import Pregnancy
+
+
+def build_reference_from_xlsform(xls_path):
+    """Parse an XLSForm and build mapping dictionaries.
+
+    Returns two dictionaries:
+        field_map - maps question name to list_name
+        choice_map - maps list_name to {name: label}
+    """
+    xls = pd.read_excel(xls_path, sheet_name=None)
+    survey_df = xls.get("survey")
+    choices_df = xls.get("choices")
+    if survey_df is None or choices_df is None:
+        return {}, {}
+
+    survey_df.columns = [c.strip().lower() for c in survey_df.columns]
+    choices_df.columns = [c.strip().lower() for c in choices_df.columns]
+
+    field_map = {}
+    for _, row in survey_df.iterrows():
+        qtype = str(row.get("type", ""))
+        name = row.get("name")
+        if not name or not qtype.startswith("select"):
+            continue
+        list_name = qtype.split()[-1]
+        field_map[name] = list_name
+
+    choice_map = {}
+    for _, row in choices_df.iterrows():
+        list_name = row.get("list_name")
+        name = row.get("name")
+        if list_name is None or name is None:
+            continue
+        # use first label column available
+        label_cols = [c for c in choices_df.columns if c.startswith("label")]
+        label = row.get(label_cols[0]) if label_cols else row.get("label")
+        if pd.isna(label):
+            label = name
+        choice_map.setdefault(list_name, {})[str(name)] = str(label)
+
+    return field_map, choice_map
+
+
+def apply_reference_to_dataframe(df, field_map, choice_map):
+    """Replace values in df using mappings from reference tables."""
+    for field, list_name in field_map.items():
+        if field not in df.columns:
+            continue
+        mapping = choice_map.get(list_name, {})
+        df[field] = df[field].apply(lambda val, m=mapping: _map_value(val, m))
+    return df
+
+
+def _map_value(val, mapping):
+    if pd.isna(val):
+        return val
+    if isinstance(val, str) and " " in val:
+        # multi-select values come space separated
+        return ",".join(mapping.get(v, v) for v in val.split())
+    return mapping.get(str(val), val)
+
+
+def load_pregnancies_from_dataframe(df):
+    """Create Pregnancy objects from DataFrame and save to DB."""
+    model_fields = [f.name for f in Pregnancy._meta.get_fields()]
+    df = df.rename(columns=lambda c: c.rsplit("-", 1)[-1])
+    field_case_mapper = {f.lower(): f for f in model_fields}
+    df = df.rename(columns=lambda c: field_case_mapper.get(c.lower(), c))
+    common = [c for c in df.columns if c in model_fields]
+    df = df[common]
+    objs = [Pregnancy(**row) for row in df.to_dict(orient="records")]
+    new_objs = bulk_create_with_history(objs, Pregnancy)
+    return new_objs


### PR DESCRIPTION
## Summary
- add utils to build ODK choice reference and load pregnancies
- add management command `load_pregnancy_csv`

## Testing
- `pre-commit run --files va_explorer/va_data_management/utils/pregnancy_loading.py va_explorer/va_data_management/management/commands/load_pregnancy_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_686dbcdf2da48329a5d3feb3515ca0b1