### PR TITLE
Fix migration default field

### DIFF
--- a/va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py
+++ b/va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='household',
             name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False, default=0),
+            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
         ),
         migrations.AlterField(
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='pregnancy',
             name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False, default=0),
+            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
         ),
         migrations.AlterField(
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='pregnancyoutcome',
             name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False, default=0),
+            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
         ),
         migrations.AlterField(
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='death',
             name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False, default=0),
+            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
         ),
         migrations.AlterField(


### PR DESCRIPTION
## Summary
- fix id fields in migration to avoid 'both default and identity' error

## Testing
- `pre-commit run --files va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py`
- `pytest` *(fails: unrecognized arguments --ds=config.settings.test --reuse-db)*

------
https://chatgpt.com/codex/tasks/task_e_686dcfac9e248329802e037db54c3b6e