### PR TITLE
Remove uuid fields from data models

### DIFF
--- a/va_explorer/va_data_management/migrations/0029_remove_uuid_fields.py
+++ b/va_explorer/va_data_management/migrations/0029_remove_uuid_fields.py
@@ -1,0 +1,45 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("va_data_management", "0028_auto_20250708_0000"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="household",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="householdmember",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="pregnancy",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="pregnancyoutcome",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="death",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="historicalhousehold",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="historicalpregnancy",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="historicalpregnancyoutcome",
+            name="uuid",
+        ),
+        migrations.RemoveField(
+            model_name="historicaldeath",
+            name="uuid",
+        ),
+    ]

--- a/va_explorer/va_data_management/models/death.py
+++ b/va_explorer/va_data_management/models/death.py
@@ -1,15 +1,8 @@
-import uuid
-
 from django.db import models
 from simple_history.models import HistoricalRecords
 
 
 class Death(models.Model):
-    uuid = models.UUIDField(
-        default=uuid.uuid4,
-        editable=False,
-        unique=True,
-    )
 
     deviceid = models.TextField("Device ID", blank=True)
     today = models.TextField("Date Recorded", blank=True)

--- a/va_explorer/va_data_management/models/household_census.py
+++ b/va_explorer/va_data_management/models/household_census.py
@@ -1,15 +1,8 @@
-import uuid
-
 from django.db import models
 from simple_history.models import HistoricalRecords
 
 
 class Household(models.Model):
-    uuid = models.UUIDField(
-        default=uuid.uuid4,
-        editable=False,
-        unique=True,
-    )
 
     deviceid = models.TextField("nan", blank=True)
     today = models.TextField("nan", blank=True)
@@ -241,12 +234,6 @@ class Household(models.Model):
 class HouseholdMember(models.Model):
     household = models.ForeignKey(
         "va_data_management.Household", on_delete=models.CASCADE, related_name="members"
-    )
-
-    uuid = models.UUIDField(
-        default=uuid.uuid4,
-        editable=False,
-        unique=True,
     )
 
     HH_03 = models.TextField("HH_03. Household Member Details", blank=True)

--- a/va_explorer/va_data_management/models/pregnancy.py
+++ b/va_explorer/va_data_management/models/pregnancy.py
@@ -1,15 +1,8 @@
-import uuid
-
 from django.db import models
 from simple_history.models import HistoricalRecords
 
 
 class Pregnancy(models.Model):
-    uuid = models.UUIDField(
-        default=uuid.uuid4,
-        editable=False,
-        unique=True,
-    )
     deviceid = models.TextField(blank=True)
     today = models.TextField(blank=True)
     start = models.TextField(blank=True)

--- a/va_explorer/va_data_management/models/pregnancy_outcome.py
+++ b/va_explorer/va_data_management/models/pregnancy_outcome.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.db import models
 from simple_history.models import HistoricalRecords
 
@@ -7,11 +5,6 @@ from .pregnancy import Pregnancy
 
 
 class PregnancyOutcome(models.Model):
-    uuid = models.UUIDField(
-        default=uuid.uuid4,
-        editable=False,
-        unique=True,
-    )
     pregnancy = models.ForeignKey(
         Pregnancy, on_delete=models.CASCADE, related_name="outcomes"
     )

--- a/va_explorer/va_data_management/views/deaths.py
+++ b/va_explorer/va_data_management/views/deaths.py
@@ -24,7 +24,7 @@ class Deaths(CustomAuthMixin, PermissionRequiredMixin, ListView):
     paginate_by = 15
 
     def get_queryset(self):
-        self.filter = DeathFilter(self.request.GET, queryset=Death.objects.all().order_by("-uuid"))
+        self.filter = DeathFilter(self.request.GET, queryset=Death.objects.all().order_by("-id"))
         return self.filter.qs
 
     def get_context_data(self, **kwargs):

--- a/va_explorer/va_data_management/views/households.py
+++ b/va_explorer/va_data_management/views/households.py
@@ -25,7 +25,7 @@ class Households(CustomAuthMixin, PermissionRequiredMixin, ListView):
 
     def get_queryset(self):
         # Set up filter with GET params
-        self.filter = HouseholdFilter(self.request.GET, queryset=Household.objects.all().order_by("-uuid"))
+        self.filter = HouseholdFilter(self.request.GET, queryset=Household.objects.all().order_by("-id"))
         return self.filter.qs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Summary
- drop `uuid` from household-related models and death
- order lists by primary key instead of uuid
- add migration to remove uuid columns

## Testing
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686dd2051f488329a787a12845bcef2e