### PR TITLE
Fix migration ordering issue

### DIFF
--- a/va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py
+++ b/va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py
@@ -8,19 +8,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name='household',
-            name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
-            preserve_default=False,
-        ),
         migrations.AlterField(
             model_name='household',
             name='uuid',
             field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
         ),
         migrations.AddField(
-            model_name='pregnancy',
+            model_name='household',
             name='id',
             field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
@@ -31,7 +25,7 @@ class Migration(migrations.Migration):
             field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
         ),
         migrations.AddField(
-            model_name='pregnancyoutcome',
+            model_name='pregnancy',
             name='id',
             field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
@@ -42,7 +36,7 @@ class Migration(migrations.Migration):
             field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
         ),
         migrations.AddField(
-            model_name='death',
+            model_name='pregnancyoutcome',
             name='id',
             field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
             preserve_default=False,
@@ -51,6 +45,12 @@ class Migration(migrations.Migration):
             model_name='death',
             name='uuid',
             field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+        migrations.AddField(
+            model_name='death',
+            name='id',
+            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
+            preserve_default=False,
         ),
         migrations.AddField(
             model_name='householdmember',


### PR DESCRIPTION
## Summary
- fix ordering in `0028_auto_20250708_0000.py` so uuid fields lose `primary_key` before `id` is added

## Testing
- `pre-commit run --files va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'crispy_forms')*

------
https://chatgpt.com/codex/tasks/task_e_686dd6abebfc83299c4446bab281a08b