### PR TITLE
Fix migration drop constraint issue

### DIFF
--- a/va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py
+++ b/va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py
@@ -1,5 +1,4 @@
-from django.db import migrations, models
-import uuid
+from django.db import migrations
 
 class Migration(migrations.Migration):
 
@@ -8,53 +7,53 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name='household',
-            name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_household DROP CONSTRAINT IF EXISTS va_data_management_household_pkey CASCADE;"
         ),
-        migrations.AddField(
-            model_name='household',
-            name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
-            preserve_default=False,
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_household ADD COLUMN id SERIAL PRIMARY KEY;"
         ),
-        migrations.AlterField(
-            model_name='pregnancy',
-            name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_household ADD CONSTRAINT household_uuid_key UNIQUE (uuid);"
         ),
-        migrations.AddField(
-            model_name='pregnancy',
-            name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
-            preserve_default=False,
+
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancy DROP CONSTRAINT IF EXISTS va_data_management_pregnancy_pkey CASCADE;"
         ),
-        migrations.AlterField(
-            model_name='pregnancyoutcome',
-            name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancy ADD COLUMN id SERIAL PRIMARY KEY;"
         ),
-        migrations.AddField(
-            model_name='pregnancyoutcome',
-            name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
-            preserve_default=False,
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancy ADD CONSTRAINT pregnancy_uuid_key UNIQUE (uuid);"
         ),
-        migrations.AlterField(
-            model_name='death',
-            name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancyoutcome DROP CONSTRAINT IF EXISTS va_data_management_pregnancyoutcome_pkey CASCADE;"
         ),
-        migrations.AddField(
-            model_name='death',
-            name='id',
-            field=models.AutoField(auto_created=True, primary_key=True, serialize=False),
-            preserve_default=False,
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancyoutcome ADD COLUMN id SERIAL PRIMARY KEY;"
         ),
-        migrations.AddField(
-            model_name='householdmember',
-            name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancyoutcome ADD CONSTRAINT pregnancyoutcome_uuid_key UNIQUE (uuid);"
+        ),
+
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_death DROP CONSTRAINT IF EXISTS va_data_management_death_pkey CASCADE;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_death ADD COLUMN id SERIAL PRIMARY KEY;"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_death ADD CONSTRAINT death_uuid_key UNIQUE (uuid);"
+        ),
+
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_householdmember ADD COLUMN uuid UUID DEFAULT gen_random_uuid();"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_householdmember ADD CONSTRAINT householdmember_household_id_fkey FOREIGN KEY (household_id) REFERENCES va_data_management_household(id);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE va_data_management_pregnancyoutcome ADD CONSTRAINT pregnancyoutcome_pregnancy_id_fkey FOREIGN KEY (pregnancy_id) REFERENCES va_data_management_pregnancy(id);"
         ),
     ]


### PR DESCRIPTION
## Summary
- fix migration 0028 to drop pk constraints with cascade and recreate them

## Testing
- `pre-commit run --files va_explorer/va_data_management/migrations/0028_auto_20250708_0000.py`


------
https://chatgpt.com/codex/tasks/task_e_686de29209148329beed975747b8ae95