### PR TITLE
Add ODK form CSV import

### DIFF
--- a/va_explorer/va_data_management/management/commands/load_form_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_form_csv.py
@@ -1,0 +1,54 @@
+import argparse
+from collections import defaultdict
+
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+
+from va_explorer.va_data_management.models import (
+    Death,
+    Household,
+    HouseholdMember,
+    ODKFormChoice,
+    Pregnancy,
+    PregnancyOutcome,
+)
+
+FORM_MODEL_MAP = {
+    "household": Household,
+    "household_member": HouseholdMember,
+    "pregnancy": Pregnancy,
+    "pregnancy_outcome": PregnancyOutcome,
+    "death": Death,
+}
+
+
+class Command(BaseCommand):
+    help = "Load CSV data for a form using ODK definition reference"
+
+    def add_arguments(self, parser):
+        parser.add_argument("form_name", choices=FORM_MODEL_MAP.keys())
+        parser.add_argument("csv_file", type=argparse.FileType("r"))
+
+    def handle(self, *args, **options):
+        form_name = options["form_name"]
+        csv_file = options["csv_file"]
+
+        if not ODKFormChoice.objects.filter(form_name=form_name).exists():
+            raise CommandError(f"Definition for form '{form_name}' has not been loaded")
+
+        df = pd.read_csv(csv_file)
+
+        # Build mapping of field -> value -> label
+        lookup = defaultdict(dict)
+        for choice in ODKFormChoice.objects.filter(form_name=form_name):
+            lookup[choice.field_name][choice.value] = choice.label
+
+        for field, mapping in lookup.items():
+            if field in df.columns:
+                df[field] = df[field].map(lambda v, _map=mapping: _map.get(str(v), v))
+
+        model = FORM_MODEL_MAP[form_name]
+        objects = [model(**row) for row in df.to_dict(orient="records")]
+        model.objects.bulk_create(objects)
+
+        self.stdout.write(f"Imported {len(objects)} records for {form_name}")

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
@@ -1,0 +1,38 @@
+import argparse
+from collections import defaultdict
+
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+
+from va_explorer.va_data_management.models import ODKFormChoice, Pregnancy
+
+
+class Command(BaseCommand):
+    """Load a pregnancy CSV using the previously loaded ODK definition."""
+
+    help = "Load pregnancy CSV data"
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv_file", type=argparse.FileType("r"))
+
+    def handle(self, *args, **options):
+        form_name = "pregnancy"
+        csv_file = options["csv_file"]
+
+        if not ODKFormChoice.objects.filter(form_name=form_name).exists():
+            raise CommandError("Definition for form 'pregnancy' has not been loaded")
+
+        df = pd.read_csv(csv_file)
+
+        lookup = defaultdict(dict)
+        for choice in ODKFormChoice.objects.filter(form_name=form_name):
+            lookup[choice.field_name][choice.value] = choice.label
+
+        for field, mapping in lookup.items():
+            if field in df.columns:
+                df[field] = df[field].map(lambda v, _m=mapping: _m.get(str(v), v))
+
+        objects = [Pregnancy(**row) for row in df.to_dict(orient="records")]
+        Pregnancy.objects.bulk_create(objects)
+
+        self.stdout.write(f"Imported {len(objects)} records for pregnancy")

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_definition.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_definition.py
@@ -1,0 +1,53 @@
+import argparse
+import re
+
+import pandas as pd
+from django.core.management.base import BaseCommand
+
+from va_explorer.va_data_management.models import ODKFormChoice
+
+
+class Command(BaseCommand):
+    """Load the pregnancy ODK XLSForm definition."""
+
+    help = "Load pregnancy form definition"
+
+    def add_arguments(self, parser):
+        parser.add_argument("definition_file", type=argparse.FileType("rb"))
+
+    def handle(self, *args, **options):
+        form_name = "pregnancy"
+        definition_file = options["definition_file"]
+
+        survey = pd.read_excel(definition_file, sheet_name="survey")
+        choices = pd.read_excel(definition_file, sheet_name="choices")
+
+        label_col = None
+        for col in choices.columns:
+            if str(col).lower().startswith("label"):
+                label_col = col
+                break
+        if not label_col:
+            self.stderr.write("Could not find label column in choices sheet")
+            return
+
+        created = 0
+        for _, srow in survey.iterrows():
+            qtype = str(srow.get("type", ""))
+            match = re.match(r"select_(?:one|multiple)\s+(.+)", qtype)
+            if not match:
+                continue
+            list_name = match.group(1)
+            field = srow.get("name")
+            if not field:
+                continue
+            sub = choices[choices["list_name"] == list_name]
+            for _, crow in sub.iterrows():
+                ODKFormChoice.objects.update_or_create(
+                    form_name=form_name,
+                    field_name=field,
+                    value=str(crow["name"]),
+                    defaults={"label": str(crow[label_col])},
+                )
+                created += 1
+        self.stdout.write(f"Loaded {created} choices for form {form_name}")

--- a/va_explorer/va_data_management/migrations/0031_odk_form_choice.py
+++ b/va_explorer/va_data_management/migrations/0031_odk_form_choice.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("va_data_management", "0030_merge_20250709_0208"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ODKFormChoice",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("form_name", models.CharField(max_length=100)),
+                ("field_name", models.CharField(max_length=100)),
+                ("value", models.TextField()),
+                ("label", models.TextField()),
+            ],
+            options={
+                "unique_together": {("form_name", "field_name", "value")},
+            },
+        ),
+    ]
+

--- a/va_explorer/va_data_management/models/__init__.py
+++ b/va_explorer/va_data_management/models/__init__.py
@@ -1,27 +1,29 @@
-from .household_census import Household
+from .death import Death
+from .household_census import Household, HouseholdMember
+from .odk_reference import ODKFormChoice
 from .pregnancy import Pregnancy
 from .pregnancy_outcome import PregnancyOutcome
-from .death import Death
 from .verbal_autopsy import (
-    VerbalAutopsy, 
-    Location, 
-    CauseCodingIssue, 
-    questions_to_autodetect_duplicates,
+    CauseCodingIssue,
     CauseOfDeath,
     CODCodesDHIS,
-    DhisStatus
+    DhisStatus,
+    Location,
+    VerbalAutopsy,
+    questions_to_autodetect_duplicates,
 )
 
-__all__ = [
-    'Household',
-    'Pregnancy',
-    'PregnancyOutcome',
-    'Death',
-    'VerbalAutopsy', 
-    'Location',
-    'CauseCodingIssue',
-    'questions_to_autodetect_duplicates',
-    'CauseOfDeath',
-    'CODCodesDHIS',
-     'DhisStatus'
+__all__ = [    "Household",
+    "HouseholdMember",
+    "Pregnancy",
+    "PregnancyOutcome",
+    "Death",
+    "VerbalAutopsy",
+    "Location",
+    "CauseCodingIssue",
+    "questions_to_autodetect_duplicates",
+    "CauseOfDeath",
+    "CODCodesDHIS",
+    "DhisStatus",
+    "ODKFormChoice",
 ]

--- a/va_explorer/va_data_management/models/odk_reference.py
+++ b/va_explorer/va_data_management/models/odk_reference.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+
+class ODKFormChoice(models.Model):
+    form_name = models.CharField(max_length=100)
+    field_name = models.CharField(max_length=100)
+    value = models.TextField()
+    label = models.TextField()
+
+    class Meta:
+        unique_together = ("form_name", "field_name", "value")
+
+    def __str__(self):
+        return f"{self.form_name}:{self.field_name} {self.value}->{self.label}"

--- a/va_explorer/va_data_management/tests/test_form_import.py
+++ b/va_explorer/va_data_management/tests/test_form_import.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from django.core.management import CommandError, call_command
+
+from va_explorer.va_data_management.models import ODKFormChoice, Pregnancy
+
+pytestmark = pytest.mark.django_db
+
+
+def make_definition(tmpdir):
+    survey = pd.DataFrame(
+        {
+            "type": ["select_one yesno"],
+            "name": ["consent"],
+            "label": ["Consent"],
+        }
+    )
+    choices = pd.DataFrame(
+        {
+            "list_name": ["yesno", "yesno"],
+            "name": ["1", "0"],
+            "label": ["Yes", "No"],
+        }
+    )
+    xls_path = Path(tmpdir) / "def.xlsx"
+    with pd.ExcelWriter(xls_path) as writer:
+        survey.to_excel(writer, sheet_name="survey", index=False)
+        choices.to_excel(writer, sheet_name="choices", index=False)
+    return xls_path
+
+
+def test_import_definition_and_csv(tmp_path):
+    definition = make_definition(tmp_path)
+    call_command("load_pregnancy_definition", str(definition))
+    assert ODKFormChoice.objects.count() == 2
+
+    csv_path = Path(tmp_path) / "data.csv"
+    csv_path.write_text("consent\n1\n")
+    call_command("load_pregnancy_csv", str(csv_path))
+    preg = Pregnancy.objects.get()
+    assert preg.consent == "Yes"
+
+
+def test_import_without_definition(tmp_path):
+    csv_path = Path(tmp_path) / "data.csv"
+    csv_path.write_text("consent\n1\n")
+    with pytest.raises(CommandError):
+        call_command("load_pregnancy_csv", str(csv_path))


### PR DESCRIPTION
## Summary
- support storing choice labels from XLSForm
- add commands to load form definition and CSV
- tests for new CSV import logic
- add dedicated pregnancy commands

## Testing
- `ruff check va_explorer/va_data_management/management/commands/load_pregnancy_definition.py va_explorer/va_data_management/management/commands/load_pregnancy_csv.py va_explorer/va_data_management/tests/test_form_import.py va_explorer/va_data_management/management/commands/load_odk_definition.py va_explorer/va_data_management/management/commands/load_form_csv.py va_explorer/va_data_management/models/odk_reference.py va_explorer/va_data_management/models/__init__.py`
- `black va_explorer/va_data_management/management/commands/load_pregnancy_definition.py va_explorer/va_data_management/management/commands/load_pregnancy_csv.py va_explorer/va_data_management/tests/test_form_import.py va_explorer/va_data_management/management/commands/load_odk_definition.py va_explorer/va_data_management/management/commands/load_form_csv.py va_explorer/va_data_management/models/odk_reference.py va_explorer/va_data_management/models/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django_celery_beat')*


------
https://chatgpt.com/codex/tasks/task_e_686df547ee748329a07927cc2383a398