### PR TITLE
Add death data loading commands

### DIFF
--- a/va_explorer/va_data_management/management/commands/load_death_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_death_csv.py
@@ -1,0 +1,42 @@
+import argparse
+from collections import defaultdict
+
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+
+from va_explorer.va_data_management.models import ODKFormChoice, Death
+
+
+class DeathCSVLoader(BaseCommand):
+    """Load a death CSV using the previously loaded ODK definition."""
+
+    help = "Load death CSV data"
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv_file", type=argparse.FileType("r"))
+
+    def handle(self, *args, **options):
+        form_name = "death"
+        csv_file = options["csv_file"]
+
+        if not ODKFormChoice.objects.filter(form_name=form_name).exists():
+            raise CommandError("Definition for form 'death' has not been loaded")
+
+        df = pd.read_csv(csv_file)
+
+        lookup = defaultdict(dict)
+        for choice in ODKFormChoice.objects.filter(form_name=form_name):
+            lookup[choice.field_name][choice.value] = choice.label
+
+        for field, mapping in lookup.items():
+            if field in df.columns:
+                df[field] = df[field].map(lambda v, _m=mapping: _m.get(str(v), v))
+
+        objects = [Death(**row) for row in df.to_dict(orient="records")]
+        Death.objects.bulk_create(objects)
+
+        self.stdout.write(f"Imported {len(objects)} records for death")
+
+
+# Django looks for a class named Command
+Command = DeathCSVLoader

--- a/va_explorer/va_data_management/management/commands/load_death_definition.py
+++ b/va_explorer/va_data_management/management/commands/load_death_definition.py
@@ -1,0 +1,57 @@
+import argparse
+import re
+
+import pandas as pd
+from django.core.management.base import BaseCommand
+
+from va_explorer.va_data_management.models import ODKFormChoice
+
+
+class DeathDefinitionCommand(BaseCommand):
+    """Load the death ODK XLSForm definition."""
+
+    help = "Load death form definition"
+
+    def add_arguments(self, parser):
+        parser.add_argument("definition_file", type=argparse.FileType("rb"))
+
+    def handle(self, *args, **options):
+        form_name = "death"
+        definition_file = options["definition_file"]
+
+        survey = pd.read_excel(definition_file, sheet_name="survey")
+        choices = pd.read_excel(definition_file, sheet_name="choices")
+
+        label_col = None
+        for col in choices.columns:
+            if str(col).lower().startswith("label"):
+                label_col = col
+                break
+        if not label_col:
+            self.stderr.write("Could not find label column in choices sheet")
+            return
+
+        created = 0
+        for _, srow in survey.iterrows():
+            qtype = str(srow.get("type", ""))
+            match = re.match(r"select_(?:one|multiple)\s+(.+)", qtype)
+            if not match:
+                continue
+            list_name = match.group(1)
+            field = srow.get("name")
+            if not field:
+                continue
+            sub = choices[choices["list_name"] == list_name]
+            for _, crow in sub.iterrows():
+                ODKFormChoice.objects.update_or_create(
+                    form_name=form_name,
+                    field_name=field,
+                    value=str(crow["name"]),
+                    defaults={"label": str(crow[label_col])},
+                )
+                created += 1
+        self.stdout.write(f"Loaded {created} choices for form {form_name}")
+
+
+# Django looks for a class named Command
+Command = DeathDefinitionCommand

--- a/va_explorer/va_data_management/tests/test_form_import.py
+++ b/va_explorer/va_data_management/tests/test_form_import.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from django.core.management import CommandError, call_command
 
-from va_explorer.va_data_management.models import ODKFormChoice, Pregnancy
+from va_explorer.va_data_management.models import ODKFormChoice, Pregnancy, Death
 
 pytestmark = pytest.mark.django_db
 
@@ -43,8 +43,27 @@ def test_import_definition_and_csv(tmp_path):
     assert preg.consent == "Yes"
 
 
+def test_death_import_definition_and_csv(tmp_path):
+    definition = make_definition(tmp_path)
+    call_command("load_death_definition", str(definition))
+    assert ODKFormChoice.objects.filter(form_name="death").count() == 2
+
+    csv_path = Path(tmp_path) / "data.csv"
+    csv_path.write_text("consent\n1\n")
+    call_command("load_death_csv", str(csv_path))
+    death = Death.objects.get()
+    assert death.consent == "Yes"
+
+
 def test_import_without_definition(tmp_path):
     csv_path = Path(tmp_path) / "data.csv"
     csv_path.write_text("consent\n1\n")
     with pytest.raises(CommandError):
         call_command("load_pregnancy_csv", str(csv_path))
+
+
+def test_death_import_without_definition(tmp_path):
+    csv_path = Path(tmp_path) / "data.csv"
+    csv_path.write_text("consent\n1\n")
+    with pytest.raises(CommandError):
+        call_command("load_death_csv", str(csv_path))


### PR DESCRIPTION
## Summary
- add management command to load death form definition
- add management command to load death CSV data
- test that death CSV import works and requires definitions

## Testing
- `pytest va_explorer/va_data_management/tests/test_form_import.py::test_death_import_definition_and_csv` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e24b01a34832992f087392ed37e9f