### PR TITLE
Add pregnancy outcome import commands

### DIFF
--- a/va_explorer/va_data_management/management/commands/load_pregnancy_outcome_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_outcome_csv.py
@@ -1,0 +1,43 @@
+import argparse
+from collections import defaultdict
+
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+
+from va_explorer.va_data_management.models import (
+    ODKFormChoice,
+    PregnancyOutcome,
+)
+
+
+class Command(BaseCommand):
+    """Load a pregnancy outcome CSV using the previously loaded ODK definition."""
+
+    help = "Load pregnancy outcome CSV data"
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv_file", type=argparse.FileType("r"))
+
+    def handle(self, *args, **options):
+        form_name = "pregnancy_outcome"
+        csv_file = options["csv_file"]
+
+        if not ODKFormChoice.objects.filter(form_name=form_name).exists():
+            raise CommandError(
+                "Definition for form 'pregnancy_outcome' has not been loaded"
+            )
+
+        df = pd.read_csv(csv_file)
+
+        lookup = defaultdict(dict)
+        for choice in ODKFormChoice.objects.filter(form_name=form_name):
+            lookup[choice.field_name][choice.value] = choice.label
+
+        for field, mapping in lookup.items():
+            if field in df.columns:
+                df[field] = df[field].map(lambda v, _m=mapping: _m.get(str(v), v))
+
+        objects = [PregnancyOutcome(**row) for row in df.to_dict(orient="records")]
+        PregnancyOutcome.objects.bulk_create(objects)
+
+        self.stdout.write(f"Imported {len(objects)} records for pregnancy_outcome")

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_outcome_definition.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_outcome_definition.py
@@ -1,0 +1,53 @@
+import argparse
+import re
+
+import pandas as pd
+from django.core.management.base import BaseCommand
+
+from va_explorer.va_data_management.models import ODKFormChoice
+
+
+class Command(BaseCommand):
+    """Load the pregnancy outcome ODK XLSForm definition."""
+
+    help = "Load pregnancy outcome form definition"
+
+    def add_arguments(self, parser):
+        parser.add_argument("definition_file", type=argparse.FileType("rb"))
+
+    def handle(self, *args, **options):
+        form_name = "pregnancy_outcome"
+        definition_file = options["definition_file"]
+
+        survey = pd.read_excel(definition_file, sheet_name="survey")
+        choices = pd.read_excel(definition_file, sheet_name="choices")
+
+        label_col = None
+        for col in choices.columns:
+            if str(col).lower().startswith("label"):
+                label_col = col
+                break
+        if not label_col:
+            self.stderr.write("Could not find label column in choices sheet")
+            return
+
+        created = 0
+        for _, srow in survey.iterrows():
+            qtype = str(srow.get("type", ""))
+            match = re.match(r"select_(?:one|multiple)\s+(.+)", qtype)
+            if not match:
+                continue
+            list_name = match.group(1)
+            field = srow.get("name")
+            if not field:
+                continue
+            sub = choices[choices["list_name"] == list_name]
+            for _, crow in sub.iterrows():
+                ODKFormChoice.objects.update_or_create(
+                    form_name=form_name,
+                    field_name=field,
+                    value=str(crow["name"]),
+                    defaults={"label": str(crow[label_col])},
+                )
+                created += 1
+        self.stdout.write(f"Loaded {created} choices for form {form_name}")


### PR DESCRIPTION
## Summary
- implement pregnancy outcome import definition command
- implement pregnancy outcome csv loader
- test pregnancy outcome command functionality

## Testing
- `ruff check va_data_management/management/commands/load_pregnancy_outcome_*.py va_data_management/tests/test_form_import.py`
- `black va_data_management/management/commands/load_pregnancy_outcome_*.py va_data_management/tests/test_form_import.py`
- `pytest va_data_management/tests/test_form_import.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e348fc5548329a2e9a50f4344ebfe