### PR TITLE
Fix CSV import field mapping

### DIFF
--- a/va_explorer/va_data_management/management/commands/load_form_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_form_csv.py
@@ -12,6 +12,7 @@ from va_explorer.va_data_management.models import (
     Pregnancy,
     PregnancyOutcome,
 )
+from va_explorer.va_data_management.utils.loading import normalize_dataframe_columns
 
 FORM_MODEL_MAP = {
     "household": Household,
@@ -37,6 +38,8 @@ class Command(BaseCommand):
             raise CommandError(f"Definition for form '{form_name}' has not been loaded")
 
         df = pd.read_csv(csv_file)
+        model = FORM_MODEL_MAP[form_name]
+        df = normalize_dataframe_columns(df, model)
 
         # Build mapping of field -> value -> label
         lookup = defaultdict(dict)
@@ -47,7 +50,6 @@ class Command(BaseCommand):
             if field in df.columns:
                 df[field] = df[field].map(lambda v, _map=mapping: _map.get(str(v), v))
 
-        model = FORM_MODEL_MAP[form_name]
         objects = [model(**row) for row in df.to_dict(orient="records")]
         model.objects.bulk_create(objects)
 

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
@@ -5,6 +5,7 @@ import pandas as pd
 from django.core.management.base import BaseCommand, CommandError
 
 from va_explorer.va_data_management.models import ODKFormChoice, Pregnancy
+from va_explorer.va_data_management.utils.loading import normalize_dataframe_columns
 
 
 class Command(BaseCommand):
@@ -23,6 +24,7 @@ class Command(BaseCommand):
             raise CommandError("Definition for form 'pregnancy' has not been loaded")
 
         df = pd.read_csv(csv_file)
+        df = normalize_dataframe_columns(df, Pregnancy)
 
         lookup = defaultdict(dict)
         for choice in ODKFormChoice.objects.filter(form_name=form_name):

--- a/va_explorer/va_data_management/management/commands/load_pregnancy_outcome_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_outcome_csv.py
@@ -8,6 +8,7 @@ from va_explorer.va_data_management.models import (
     ODKFormChoice,
     PregnancyOutcome,
 )
+from va_explorer.va_data_management.utils.loading import normalize_dataframe_columns
 
 
 class Command(BaseCommand):
@@ -28,6 +29,7 @@ class Command(BaseCommand):
             )
 
         df = pd.read_csv(csv_file)
+        df = normalize_dataframe_columns(df, PregnancyOutcome)
 
         lookup = defaultdict(dict)
         for choice in ODKFormChoice.objects.filter(form_name=form_name):

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -21,6 +21,24 @@ from ..constants import _checkbox_choices
 User = get_user_model()
 
 
+def normalize_dataframe_columns(df, model):
+    """Rename and filter DataFrame columns to align with model fields."""
+
+    # Remove prefixes before the last dash to match our model fields
+    df = df.rename(columns=lambda c: c.rsplit("-", 1)[-1])
+
+    model_fields = pd.Index([f.name for f in model._meta.get_fields()])
+
+    # Map column names ignoring case
+    case_map = {f.lower(): f for f in model_fields}
+    df = df.rename(columns=lambda c: case_map.get(c.lower(), c))
+
+    # Keep only columns that exist on the model
+    df = df[[c for c in df.columns if c in model_fields]]
+
+    return df
+
+
 # load VA records into django database
 def load_records_from_dataframe(record_df, random_locations=False, debug=False):
     logger = None if not debug else logging.getLogger("debug")


### PR DESCRIPTION
## Summary
- align CSV column names to model fields before importing
- use new `normalize_dataframe_columns` helper
- update pregnancy-related CSV loaders to call the helper

## Testing
- `ruff check va_explorer/va_data_management/management/commands/load_pregnancy_csv.py va_explorer/va_data_management/management/commands/load_pregnancy_outcome_csv.py va_explorer/va_data_management/management/commands/load_form_csv.py va_explorer/va_data_management/utils/loading.py`
- `pytest va_explorer/va_data_management/tests/test_form_import.py::test_import_definition_and_csv -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f587737d88329a48a2c1a4c764daf