### PR TITLE
Fix label mapping for pregnancy CSV

### DIFF
--- a/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
+++ b/va_explorer/va_data_management/management/commands/load_pregnancy_csv.py
@@ -1,10 +1,11 @@
 import argparse
-import numpy as np
+
 import pandas as pd
 from django.core.management.base import BaseCommand, CommandError
 
 from va_explorer.va_data_management.models import ODKFormChoice, Pregnancy
 from va_explorer.va_data_management.utils.loading import normalize_dataframe_columns
+
 
 class Command(BaseCommand):
     """Load a pregnancy CSV using the previously loaded ODK definition."""
@@ -21,14 +22,36 @@ class Command(BaseCommand):
         if not ODKFormChoice.objects.filter(form_name=form_name).exists():
             raise CommandError("Definition for form 'pregnancy' has not been loaded")
 
-        # Read the CSV file into a DataFrame
+        # Read the CSV file into a DataFrame and normalize the columns early so
+        # that lookups work regardless of CSV header formatting.
         df = pd.read_csv(csv_file)
-        df.columns = df.columns.str.strip()  # strip whitespace from headers
+        df.columns = df.columns.str.strip()
+        df = normalize_dataframe_columns(df, Pregnancy)
 
-        # List of columns to apply value -> label replacement
+        # List of columns to apply value -> label replacement.  These names
+        # correspond to normalized model fields, so hyphens are replaced with
+        # underscores.
         odk_map_columns = [
-            'province', 'district', 'constituency', 'ward', 'ea', 'PE-03', 'PE-08', 'PE-09', 'PE-10', 'PE-11',
-            'PE-12', 'PE-12A', 'PE-13', 'PE-14', 'PE-15', 'PE-16', 'PE-17', 'PE-18', 'PE-23', 'PE-24'
+            "province",
+            "district",
+            "constituency",
+            "ward",
+            "ea",
+            "PE_03",
+            "PE_08",
+            "PE_09",
+            "PE_10",
+            "PE_11",
+            "PE_12",
+            "PE_12A",
+            "PE_13",
+            "PE_14",
+            "PE_15",
+            "PE_16",
+            "PE_17",
+            "PE_18",
+            "PE_23",
+            "PE_24",
         ]
         odk_map_columns = [c.strip() for c in odk_map_columns]
 
@@ -37,9 +60,10 @@ class Command(BaseCommand):
         odk_map = {}
         for choice in all_choices:
             field_name = choice.field_name.strip()
+            value = str(choice.value).strip()
             if field_name not in odk_map:
                 odk_map[field_name] = {}
-            odk_map[field_name][str(choice.value)] = choice.label
+            odk_map[field_name][value] = choice.label
 
         # --- Robust value-to-label function ---
         def lookup_label(col, v):
@@ -47,7 +71,7 @@ class Command(BaseCommand):
             Convert a code value in the DataFrame (may be float, int, string, nan) to odk_map label.
             Handles zero-padded, integer, float, and string codes.
             """
-            if pd.isnull(v) or str(v).lower() == 'nan':
+            if pd.isnull(v) or str(v).lower() == "nan":
                 return v  # Keep as NaN/None
             v_str = str(v).strip()
             # Try exact match
@@ -72,9 +96,11 @@ class Command(BaseCommand):
         # --- Perform label replacement ---
         for col in odk_map_columns:
             if col in df.columns and col in odk_map:
-                print(f"Mapping csv column '{col}' with odk_map keys {list(odk_map[col].keys())}")
+                print(
+                    f"Mapping csv column '{col}' with odk_map keys {list(odk_map[col].keys())}"
+                )
                 print("BEFORE:", df[col].unique())
-                df[col] = df[col].map(lambda v: lookup_label(col, v))
+                df[col] = df[col].map(lambda v, c=col: lookup_label(c, v))
                 print("AFTER:", df[col].unique())
             elif col not in df.columns:
                 print(f"Column '{col}' not in DataFrame")
@@ -88,15 +114,20 @@ class Command(BaseCommand):
         df = df.loc[:, ~df.columns.duplicated()]
 
         # Only keep columns that are model fields
-        model_fields = set([f.name for f in Pregnancy._meta.get_fields()])
+        model_fields = {f.name for f in Pregnancy._meta.get_fields()}
         df = df[[col for col in df.columns if col in model_fields]]
 
         # Identify integer fields in the model
         int_fields = [
-            f.name for f in Pregnancy._meta.get_fields()
-            if getattr(f, 'get_internal_type', lambda: None)() in [
-                'IntegerField', 'BigIntegerField', 'SmallIntegerField',
-                'PositiveIntegerField', 'PositiveSmallIntegerField'
+            f.name
+            for f in Pregnancy._meta.get_fields()
+            if getattr(f, "get_internal_type", lambda: None)()
+            in [
+                "IntegerField",
+                "BigIntegerField",
+                "SmallIntegerField",
+                "PositiveIntegerField",
+                "PositiveSmallIntegerField",
             ]
         ]
 

--- a/va_explorer/va_data_management/tests/test_form_import.py
+++ b/va_explorer/va_data_management/tests/test_form_import.py
@@ -36,6 +36,49 @@ def make_definition(tmpdir):
     return xls_path
 
 
+def make_location_definition(tmpdir):
+    """Create a definition including location fields."""
+    survey = pd.DataFrame(
+        {
+            "type": [
+                "select_one yesno",
+                "select_one loc",
+                "select_one loc",
+                "select_one loc",
+                "select_one loc",
+            ],
+            "name": ["consent", "district", "constituency", "ward", "ea"],
+            "label": ["Consent", "District", "Constituency", "Ward", "EA"],
+        }
+    )
+    choices = pd.DataFrame(
+        {
+            "list_name": [
+                "yesno",
+                "yesno",
+                "loc",
+                "loc",
+                "loc",
+                "loc",
+            ],
+            "name": ["1", "0", "1", "2", "1", "2"],
+            "label": [
+                "Yes",
+                "No",
+                "Loc1",
+                "Loc2",
+                "Loc1",
+                "Loc2",
+            ],
+        }
+    )
+    xls_path = Path(tmpdir) / "def.xlsx"
+    with pd.ExcelWriter(xls_path) as writer:
+        survey.to_excel(writer, sheet_name="survey", index=False)
+        choices.to_excel(writer, sheet_name="choices", index=False)
+    return xls_path
+
+
 def test_import_definition_and_csv(tmp_path):
     definition = make_definition(tmp_path)
     call_command("load_pregnancy_definition", str(definition))
@@ -91,3 +134,19 @@ def test_pregnancy_outcome_import_without_definition(tmp_path):
     csv_path.write_text("consent\n1\n")
     with pytest.raises(CommandError):
         call_command("load_pregnancy_outcome_csv", str(csv_path))
+
+
+def test_location_fields_case_insensitive(tmp_path):
+    """Values for location fields should be mapped regardless of header case."""
+    definition = make_location_definition(tmp_path)
+    call_command("load_pregnancy_definition", str(definition))
+
+    # CSV uses capitalized headers which should still map correctly
+    csv_path = Path(tmp_path) / "data.csv"
+    csv_path.write_text("District,Constituency,Ward,EA,Consent\n1,2,1,2,1\n")
+    call_command("load_pregnancy_csv", str(csv_path))
+    preg = Pregnancy.objects.get()
+    assert preg.district == "Loc1"
+    assert preg.constituency == "Loc2"
+    assert preg.ward == "Loc1"
+    assert preg.ea == "Loc2"


### PR DESCRIPTION
## Summary
- normalize columns before label replacement in pregnancy CSV importer
- update mapping list to underscore field names
- strip choice values on mapping and fix lambda variable capture
- add regression test covering location label mapping

## Testing
- `pre-commit run --files va_explorer/va_data_management/management/commands/load_pregnancy_csv.py va_explorer/va_data_management/tests/test_form_import.py`
- `pytest va_explorer/va_data_management/tests/test_form_import.py::test_location_fields_case_insensitive -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6872c703119483299a9a8f6ad678b928